### PR TITLE
[GIT PULL] Fix missing `sessActive` check in `accountStatement()`

### DIFF
--- a/src/KlikBCA/KlikBCA.php
+++ b/src/KlikBCA/KlikBCA.php
@@ -231,10 +231,15 @@ final class KlikBCA
 	}
 
 	/**
-	 * @return array
+	 * @return ?array
 	 */
 	public function accountStatement($startDate, $endDate = null)
 	{
+		if (!$this->sessActive) {
+			if (!$this->login())
+				return NULL;
+		}
+
 		$err = "";
 		$o = $this->curl("https://m.klikbca.com/accountstmt.do?value(actions)=acct_stmt", [
 			CURLOPT_POST       => true,


### PR DESCRIPTION
Hi @ammarfaizi2,

If accountStatement() is called when sessActive is false, it will fail
immediately because we don't have the login session yet. Make sure we
call login() if we don't have the login session. Also, update the
annotation comment to reflect the fact that accountStatement() may
return NULL.

Please pull!

Signed-off-by: Alviro Iskandar Setiawan &lt;alviro.iskandar@gnuweeb.org&gt;

```
The following changes since commit 95e4675994e1c5e826c1e017b515fb4a071b4f30:

  KlikBCA 3.0 (2022-05-14 02:56:38 +0700)

are available in the Git repository at:

  https://github.com/alviroiskandar/KlikBCA tags/KlikBCA-2022-05-14

for you to fetch changes up to 436b04c0188e425c160d60f40cfa351bd50780df:

  KlikBCA: Fix missing `sessActive` check in `accountStatement()` (2022-05-14 05:07:57 +0700)

----------------------------------------------------------------
KlikBCA-2022-05-14

----------------------------------------------------------------
Alviro Iskandar Setiawan (1):
      KlikBCA: Fix missing `sessActive` check in `accountStatement()`

 src/KlikBCA/KlikBCA.php | 7 ++++++-
 1 file changed, 6 insertions(+), 1 deletion(-)
```