### PR TITLE
[GIT PULL] refactor: remove if-else for setProxy method

### DIFF
--- a/src/KlikBCA/KlikBCA.php
+++ b/src/KlikBCA/KlikBCA.php
@@ -355,10 +355,7 @@ final class KlikBCA
 	 */
 	public function setProxy($proxy = NULL)
 	{
-		if (is_string($proxy))
-			$this->proxy = $proxy;
-		else
-			$this->proxy = NULL;
+		$this->proxy = $proxy;
 	}
 
 	/**


### PR DESCRIPTION
This pull request removes the use of if else since `$optDef[CURLOPT_PROXY] = $this->proxy;` are passed if `$this->proxy` internal variable is string (there's nothing to do with NULL or any non-string value). Resolving my own review on this PR https://github.com/ammarfaizi2/KlikBCA/pull/3